### PR TITLE
Poprawa archiwum

### DIFF
--- a/content/project/selfie.md
+++ b/content/project/selfie.md
@@ -19,7 +19,7 @@ W szczytowym momentcie nad projektem pracowało ponad 20 osób podzielonych na 3
  - elektroników i programistów niskopoziomowych
  - Zespół programistów wysokopoziomowych
 
-<img src="/images/selfie/SelfieCarolo2020FullSkład.png"  width="75%" alt="Zdjęcie zespołu przygotowującego samochód do CaroloCup 2020">
+<img src="/images/selfie/SelfieCarolo2020FullSkład.png"  width="75%" alt="Zdjęcie zespołu przygotowującego samochód do CaroloCup 2020" style="margin-left:12.5%">
 
 Do sukcesów zespołu można zaliczyć:
 

--- a/layouts/project/single.html
+++ b/layouts/project/single.html
@@ -23,16 +23,16 @@
       {{ end }}
       <div class="project__block">
         <div class="project__dates">
-            <p>
-              {{ if .Params.start_date }}
-                {{ .Params.start_date }}
-                {{ if .Params.end_date }} 
-                  - {{ .Params.end_date }} 
-                {{ else }} 
-                  - obecnie 
-                {{ end }}
+          <p>
+            {{ if .Params.start_date }}
+              {{ .Params.start_date }}
+              {{ if .Params.end_date }} 
+                - {{ .Params.end_date }} 
+              {{ else }} 
+                - obecnie 
               {{ end }}
-            </p>
+            {{ end }}
+          </p>
         </div>
         <div class="project__descr-title">Kilka słów więcej</div>
         {{ if .Params.short_description}}

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -628,6 +628,7 @@
 }
 .project__dates{
     margin-bottom: 20px;
+    margin-right: 0px;
     text-align: right;
 }
 .project__title{
@@ -640,12 +641,19 @@
     text-align:center;
     font-size:20px
 }
+.project__block:last-child{
+    width:100%;
+}
 .project__descr{
     text-align:left;
     font-size:20px
 }
+.project__descr p{
+    margin-bottom: 10px;
+}
 .project__descr img{
     max-width:100%;
+    margin: 20px;
 }
 .about__descr-title{
     font-size:40px;
@@ -659,7 +667,7 @@
     font-size:40px;
     font-weight:500;
     line-height:38px;
-    text-align:left;
+    text-align:center;
     color:black;
     margin-bottom:20px
 }
@@ -1481,7 +1489,7 @@
 .project-start__title{
     font-size:50px;
     font-weight:500;
-    line-height:38px;
+    line-height:60px;
     text-align:left;
     width:100%;
     color:white;


### PR DESCRIPTION
zmiana aby data była do prawej strony gdy nie ma zdjęcia artykułu i wycentrowany tytuł.

Dodanie manualnego sposobu ustawiania marginesu zdjęcia w artykule projektu w .md

zwiększenie line height tytułu strony projektu, np w łodzi podwodnej tytuł na nachodził na siebie jak szerokość była za mała